### PR TITLE
Allow multiple rows of same config parameter by using children

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,8 @@
 
 - name: Install the nginx packages
   apt: name={{ item }} state=present update_cache=yes
-  with_items: ubuntu_pkg
-  environment: env
+  with_items: '{{ ubuntu_pkg }}'
+  environment: '{{ env }}'
   when: ansible_os_family == "Debian"
 
 # provision directories
@@ -52,14 +52,14 @@
 
 - name: Create the configurations for sites
   template: src=site.j2 dest=/etc/nginx/sites-available/{{ item['server']['file_name'] }}
-  with_items: nginx_sites
+  with_items: '{{ nginx_sites }}'
   when: nginx_sites|lower != 'none'
   notify:
    - reload_nginx
 
 - name: Create the links to enable site configurations
   file: path=/etc/nginx/sites-enabled/{{ item['server']['file_name'] }} state=link src=/etc/nginx/sites-available/{{ item['server']['file_name'] }}
-  with_items: nginx_sites
+  with_items: '{{ nginx_sites }}'
   when: nginx_sites is defined and nginx_sites
   notify:
    - reload_nginx

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -22,7 +22,6 @@ server {
         {{ key }} {{ value }};
 {% endif %}
 {% endfor %}
-{% endfor %}
 
     }
 {% endfor %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -2,7 +2,7 @@
 
 server {
 
-{% for key,value in item.server|dictsort if key != 'file_name' %}
+{% for key,value in item.server.iteritems() if key != 'file_name' %}
     {{ key }} {{ value }};
 {% if nginx_separate_logs_per_site == True %}
 	access_log {{ nginx_log_dir}}/{{ item.server.server_name}}-{{ nginx_access_log_name}};
@@ -15,8 +15,16 @@ server {
     location {{ location.name }} { 
 {% for key,value in location|dictsort if key != 'name' %}
         {{ key }} {{ value }}; 
+{% for key, value in location.iteritems() if key != 'name' %}
+{% if value is iterable and value is not string %}
+{% for v in value %}
+        {{ key }} {{ v }};
 {% endfor %}
-
+{% else %}
+        {{ key }} {{ value }};
+{% endif %}
+{% endfor %}
+{% endfor %}
     }
 {% endfor %}
 {% endif %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -14,8 +14,6 @@ server {
 {% for location in item.location if 'location' in item %}
     location {{ location.name }} { 
 {% for key,value in location|dictsort if key != 'name' %}
-        {{ key }} {{ value }}; 
-{% for key, value in location.iteritems() if key != 'name' %}
 {% if value is iterable and value is not string %}
 {% for v in value %}
         {{ key }} {{ v }};

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -2,7 +2,7 @@
 
 server {
 
-{% for key,value in item.server.iteritems() if key != 'file_name' %}
+{% for key,value in item.server|dictsort if key != 'file_name' %}
     {{ key }} {{ value }};
 {% if nginx_separate_logs_per_site == True %}
 	access_log {{ nginx_log_dir}}/{{ item.server.server_name}}-{{ nginx_access_log_name}};
@@ -25,6 +25,7 @@ server {
 {% endif %}
 {% endfor %}
 {% endfor %}
+
     }
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Opening this mostly for discussion of this feature or direct merge if you agree.

The problem it solves is previously mentioned (https://github.com/ginsys/ansible-role-nginx/pull/4#issuecomment-350783969)
```yaml
    location:
      - name: /
        proxy_set_header:
          - Host $host
          - X-Real-IP $remote_addr
          - X-Forwarded-For $proxy_add_x_forwarded_for
          - X-Forwarded-Host  $server_name

```

You want multiple proxy_set_header lines but you are not allowed to re-use the same key (obviously) so in this way a key with children gets transformed into:

```
# Ansible managed

server {

    listen 80;

    proxy_set_header X-Forwarded-For $remote_addr;

    server_name 10.0.0.2;

    location / {
        access_log /var/log/nginx/seahub.access.log;
        client_max_body_size 0;
        error_log /var/log/nginx/seahub.error.log;
        proxy_pass 127.0.0.1:8000;
        proxy_read_timeout 1200s;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host  $server_name;

    }
    location /seafhttp {
        client_max_body_size 0;
        proxy_connect_timeout 36000s;;
        proxy_pass http://127.0.0.1:8082;
        proxy_read_timeout 36000s;
        proxy_send_timeout 36000s;
        proxy_set_header X-Ass-In-Face;
        rewrite ^/seafhttp(.*)$ $1 break;
        send_timeout 36000s;

    }
    location /media {
        root /home/seafile/ginsys/seafile-server-latest/seahub;

    }
}
```

Multiple instances of proxy_set_header ...

I could not think of any way this could clash with other functionality given the low-level way the template just assumes multiple lines if there are children. But please share your point of view :)